### PR TITLE
Fix echo message error when the translation is invalid.

### DIFF
--- a/autoload/vtm.vim
+++ b/autoload/vtm.vim
@@ -191,8 +191,8 @@ function! s:Echo(contents) abort
     let translation = a:contents['query'] .
         \ ' ==> ' .
         \ a:contents['translation'] .
-        \ ' [' . a:contents['phonetic'] . '] ' .
-        \ join(a:contents['explain'], ' ')
+        \ ' [' . get(a:contents, 'phonetic', '') . '] ' .
+        \ join(get(a:contents, 'explain', []), ' ')
 
     echomsg translation
 endfunction


### PR DESCRIPTION
The `a:contents` variable has no `phonetic` and `explain` keys when
the translation is invalid. Use the `get` method to get the value and get a
default value when it's no exist.

close #4