### PR TITLE
Fix no support google translate url

### DIFF
--- a/script/translator.py
+++ b/script/translator.py
@@ -248,7 +248,7 @@ class GoogleTranslator(BaseTranslator):
     def __init__(self):
         super(GoogleTranslator, self).__init__("google")
         self._host = "translate.googleapis.com"
-        self._cnhost = "translate.google.com.hk"
+        self._cnhost = "translate.googleapis.com"
 
     def get_url(self, sl, tl, qry):
         http_host = self._cnhost if "zh" in tl else self._host


### PR DESCRIPTION
Google Translate no longer supports China, continuing to use this url will cause the translation to fail.